### PR TITLE
(GH-1) Add POC for alpine docker image

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,0 +1,7 @@
+FROM puppet/puppet-agent-alpine
+
+RUN apk add --update git \
+    && git clone https://github.com/lingua-pupuli/puppet-editor-services.git
+
+ENTRYPOINT ["/usr/bin/ruby"]
+CMD ["/puppet-editor-services/puppet-languageserver", "--ip=0.0.0.0"]

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -3,5 +3,8 @@ FROM puppet/puppet-agent-alpine
 RUN apk add --update git \
     && git clone https://github.com/lingua-pupuli/puppet-editor-services.git
 
+EXPOSE 8082
+
 ENTRYPOINT ["/usr/bin/ruby"]
-CMD ["/puppet-editor-services/puppet-languageserver", "--ip=0.0.0.0"]
+
+CMD ["/puppet-editor-services/puppet-languageserver", "--ip=0.0.0.0", "--port=8082", "--timeout=0", "--debug=STDOUT", "--no-stop"]


### PR DESCRIPTION
This commit adds a proof of concept dockerfile for building
an Alpine-linux based image for the Puppet language server.
It leverages the puppet-in-docker image to simply add the
languageserver per instructions into the container. This
should be cleaned up in a future commit to pull only the
strictly necessary files instead of cloning the repo and
running the language server from within that clone.