### PR TITLE
(GH-1) Versioned Language Server Docker Container

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,10 +1,27 @@
 FROM puppet/puppet-agent-alpine
 
-RUN apk add --update git \
-    && git clone https://github.com/lingua-pupuli/puppet-editor-services.git
+ARG LANG_SERVER_VERSION=0.12.0
+ARG IMAGE_NAME=lingua-pupuli/languageserver:0.12.0
+
+LABEL maintainer="Lingua-Pupuli Team" \
+        readme.md="https://github.com/lingua-pupuli/images/blob/master/README.md" \
+        description="This Dockerfile will install the latest release of the Puppet Language Server." \
+        org.label-schema.usage="https://github.com/lingua-pupuli/images/blob/master/README.md#run-the-docker-image-you-built" \
+        org.label-schema.url="https://github.com/lingua-pupuli/images/blob/master/README.md" \
+        org.label-schema.vcs-url="https://github.com/lingua-pupuli/images" \
+        org.label-schema.name="languageserver" \
+        org.label-schema.vendor="lingua-pupuli" \
+        org.label-schema.version=${LANG_SERVER_VERSION}} \
+        org.label-schema.schema-version="1.0" 
+
+ADD "https://github.com/lingua-pupuli/puppet-editor-services/releases/download/${LANG_SERVER_VERSION}/puppet_editor_services_${LANG_SERVER_VERSION}.tar.gz" /puppet_editor_services_${LANG_SERVER_VERSION}.tar.gz
+
+RUN mkdir /puppet_editor_services \
+    && cd /puppet_editor_services \
+    && tar -xzf /puppet_editor_services_${LANG_SERVER_VERSION}.tar.gz
 
 EXPOSE 8082
 
 ENTRYPOINT ["/usr/bin/ruby"]
 
-CMD ["/puppet-editor-services/puppet-languageserver", "--ip=0.0.0.0", "--port=8082", "--timeout=0", "--debug=STDOUT", "--no-stop"]
+CMD ["/puppet_editor_services/puppet-languageserver", "--ip=0.0.0.0", "--port=8082", "--timeout=0", "--debug=STDOUT", "--no-stop"]

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,0 +1,7 @@
+FROM puppet/puppet-agent-alpine
+
+RUN apk add --update git \
+    && git clone https://github.com/lingua-pupuli/puppet-editor-services.git
+
+ENTRYPOINT ["/usr/bin/ruby"]
+CMD ["/puppet-editor-services/puppet-languageserver", "--ip=0.0.0.0"]

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -3,5 +3,8 @@ FROM puppet/puppet-agent-alpine
 RUN apk add --update git \
     && git clone https://github.com/lingua-pupuli/puppet-editor-services.git
 
+EXPOSE 8082
+
 ENTRYPOINT ["/usr/bin/ruby"]
-CMD ["/puppet-editor-services/puppet-languageserver", "--ip=0.0.0.0"]
+
+CMD ["/puppet-editor-services/puppet-languageserver", "--ip=0.0.0.0", "--port=8082", "--timeout=0", "--debug=STDOUT", "--no-stop"]


### PR DESCRIPTION
This builds on PR #1 but takes a different tack by downloading an archive and extracting instead of performing a git clone. This allows pulling a specific release of the language server instead of cloning HEAD on master.