### PR TITLE
(GH-4) Update alpine image to latest puppet-agent

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM puppet/puppet-agent-alpine
+FROM puppet/puppet-agent-alpine:latest
 
 ARG LANG_SERVER_VERSION=0.12.0
 ARG IMAGE_NAME=lingua-pupuli/languageserver:0.12.0
@@ -12,7 +12,7 @@ LABEL maintainer="Lingua-Pupuli Team" \
         org.label-schema.name="languageserver" \
         org.label-schema.vendor="lingua-pupuli" \
         org.label-schema.version=${LANG_SERVER_VERSION}} \
-        org.label-schema.schema-version="1.0" 
+        org.label-schema.schema-version="1.0"
 
 ADD "https://github.com/lingua-pupuli/puppet-editor-services/releases/download/${LANG_SERVER_VERSION}/puppet_editor_services_${LANG_SERVER_VERSION}.tar.gz" /puppet_editor_services_${LANG_SERVER_VERSION}.tar.gz
 


### PR DESCRIPTION
This commit updates the alpine image to the 6.0.4 version of
puppet-agent.