### PR TITLE
(wip)(GH-6) Dockerfile for windowservercore

### DIFF
--- a/windowsservercore/DockerFile
+++ b/windowsservercore/DockerFile
@@ -1,0 +1,30 @@
+FROM jpogran/puppet-agent-windowsservercore:latest
+
+LABEL maintainer="Lingua-Pupuli Team" \
+        readme.md="https://github.com/lingua-pupuli/images/blob/master/README.md" \
+        description="This Dockerfile will install the latest release of the Puppet Language Server." \
+        org.label-schema.usage="https://github.com/lingua-pupuli/images/blob/master/README.md#run-the-docker-image-you-built" \
+        org.label-schema.url="https://github.com/lingua-pupuli/images/blob/master/README.md" \
+        org.label-schema.vcs-url="https://github.com/lingua-pupuli/images" \
+        org.label-schema.name="languageserver" \
+        org.label-schema.vendor="lingua-pupuli" \
+        org.label-schema.version=${LANG_SERVER_VERSION}} \
+        org.label-schema.schema-version="1.0"
+
+ARG LANG_SERVER_VERSION=0.15.1
+ARG IMAGE_NAME=lingua-pupuli/languageserver-windowsservercore:0.15.1
+
+ENV GITHUBUSER='lingua-pupuli'
+ENV GITHUBREPO='puppet-editor-services'
+ENV RELEASENUMBER='0.15.1'
+ENV URI=https://github.com/${GITHUBUSER}/${GITHUBREPO}/releases/download/${RELEASENUMBER}/puppet_editor_services_${RELEASENUMBER}.zip
+
+RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+  Invoke-WebRequest -Uri $env:uri -OutFile 'C:/langserver.zip'; \
+  Expand-Archive -Path 'C:/langserver.zip' -DestinationPath 'C:/puppet_editor_services' -Force; \
+  Remove-Item -Path 'C:/langserver.zip';
+
+EXPOSE 8082
+
+ENTRYPOINT [ "powershell" ]
+CMD ["ruby", "C:/puppet_editor_services/puppet-languageserver", "--ip=0.0.0.0", "--port=8082", "--timeout=0", "--debug=STDOUT", "--no-stop"]


### PR DESCRIPTION
This commit adds a dockerfile for a windowservercore docker image for
the puppet-editor-services languageserver.